### PR TITLE
Modify motor config and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ For ROV 22
 roscd nautilus_description/urdf && xacro rov22.urdf.xacro > rov22.urdf && rosrun gazebo_ros spawn_model -f rov22.urdf -urdf -model rov22 -z 2
 ```
 
+**6. (Optional) Test ROV with sample data**
+
+  Be sure to source your ROS environment first.
+  ```
+  rosrun nautilus_worlds sample_data.py
+  ```
+
 ## Overview
 This is a highly portable simulation of UWROV's ROV. It's capable of being used as a stand-in for actual hardware, and can give a rough idea of how our ROV might interact with the real world.
 

--- a/src/nautilus_description/urdf/rov22.urdf
+++ b/src/nautilus_description/urdf/rov22.urdf
@@ -71,48 +71,6 @@
     <parent link="body"/>
     <child link="motor_B"/>
   </joint>
-  <link name="motor_E">
-    <inertial>
-      <mass value="0.20993692907613795"/>
-      <inertia ixx="0.4" ixy="0.0" ixz="0.0" iyy="0.4" iyz="0.0" izz="0.2"/>
-    </inertial>
-    <collision name="motor_E">
-      <geometry>
-        <cylinder length="0.033" radius="0.045"/>
-      </geometry>
-    </collision>
-    <visual name="motor_E">
-      <geometry>
-        <cylinder length="0.033" radius="0.045"/>
-      </geometry>
-    </visual>
-  </link>
-  <joint name="motor_E_joint" type="fixed">
-    <origin rpy="0.0 0.0 0.0" xyz="0.1475 -0.135 0.044"/>
-    <parent link="body"/>
-    <child link="motor_E"/>
-  </joint>
-  <link name="motor_F">
-    <inertial>
-      <mass value="0.20993692907613795"/>
-      <inertia ixx="0.4" ixy="0.0" ixz="0.0" iyy="0.4" iyz="0.0" izz="0.2"/>
-    </inertial>
-    <collision name="motor_F">
-      <geometry>
-        <cylinder length="0.033" radius="0.045"/>
-      </geometry>
-    </collision>
-    <visual name="motor_F">
-      <geometry>
-        <cylinder length="0.033" radius="0.045"/>
-      </geometry>
-    </visual>
-  </link>
-  <joint name="motor_F_joint" type="fixed">
-    <origin rpy="0.0 0.0 0.0" xyz="-0.1475 -0.135 0.044"/>
-    <parent link="body"/>
-    <child link="motor_F"/>
-  </joint>
   <link name="motor_C">
     <inertial>
       <mass value="0.20993692907613795"/>
@@ -151,9 +109,51 @@
     </visual>
   </link>
   <joint name="motor_D_joint" type="fixed">
-    <origin rpy="1.5707963267948966 0.0 0" xyz="0 -0.019 0.15"/>
+    <origin rpy="0.0 0.0 0.0" xyz="0.1475 -0.135 0.044"/>
     <parent link="body"/>
     <child link="motor_D"/>
+  </joint>
+  <link name="motor_E">
+    <inertial>
+      <mass value="0.20993692907613795"/>
+      <inertia ixx="0.4" ixy="0.0" ixz="0.0" iyy="0.4" iyz="0.0" izz="0.2"/>
+    </inertial>
+    <collision name="motor_E">
+      <geometry>
+        <cylinder length="0.033" radius="0.045"/>
+      </geometry>
+    </collision>
+    <visual name="motor_E">
+      <geometry>
+        <cylinder length="0.033" radius="0.045"/>
+      </geometry>
+    </visual>
+  </link>
+  <joint name="motor_E_joint" type="fixed">
+    <origin rpy="0.0 0.0 0.0" xyz="-0.1475 -0.135 0.044"/>
+    <parent link="body"/>
+    <child link="motor_E"/>
+  </joint>
+  <link name="motor_F">
+    <inertial>
+      <mass value="0.20993692907613795"/>
+      <inertia ixx="0.4" ixy="0.0" ixz="0.0" iyy="0.4" iyz="0.0" izz="0.2"/>
+    </inertial>
+    <collision name="motor_F">
+      <geometry>
+        <cylinder length="0.033" radius="0.045"/>
+      </geometry>
+    </collision>
+    <visual name="motor_F">
+      <geometry>
+        <cylinder length="0.033" radius="0.045"/>
+      </geometry>
+    </visual>
+  </link>
+  <joint name="motor_F_joint" type="fixed">
+    <origin rpy="1.5707963267948966 0.0 0" xyz="0 -0.019 0.15"/>
+    <parent link="body"/>
+    <child link="motor_F"/>
   </joint>
   <link name="camera1">
     <inertial>

--- a/src/nautilus_description/urdf/rov22.urdf.xacro
+++ b/src/nautilus_description/urdf/rov22.urdf.xacro
@@ -98,23 +98,23 @@
   <!-- y+ -> back -->
   <!-- z+ -> up -->
 
-  <!-- Port Bow -->
+  <!-- A: Port Bow -->
   <xacro:thrusters thrusterName="motor_A" x=".1475" y="-.283" z="-.044" r="${pi/2}" p="0.0" yaw="0"/>
 
-  <!-- Starboard Bow -->
+  <!-- B: Starboard Bow -->
   <xacro:thrusters thrusterName="motor_B" x="-.1475" y="-.283" z="-.044" r="${pi/2}" p="0.0" yaw="0"/>
 
-  <!-- Port -->
-  <xacro:thrusters thrusterName="motor_E" x=".1475" y="-.135" z=".044" r="0.0" p="0.0" yaw="0.0"/>
-
-  <!-- Starboard -->
-  <xacro:thrusters thrusterName="motor_F" x="-.1475" y="-.135" z=".044" r="0.0" p="0.0" yaw="0.0"/>
-
-  <!-- Bow -->
+  <!-- C: Bow -->
   <xacro:thrusters thrusterName="motor_C" x="0" y="-.331" z=".15" r="0" p="${pi/2}" yaw="0"/>
 
-  <!-- Stern -->
-  <xacro:thrusters thrusterName="motor_D" x="0" y="-.019" z=".15" r="${pi/2}" p="0.0" yaw="0"/>
+  <!-- D: Port -->
+  <xacro:thrusters thrusterName="motor_D" x=".1475" y="-.135" z=".044" r="0.0" p="0.0" yaw="0.0"/>
+
+  <!-- E: Starboard -->
+  <xacro:thrusters thrusterName="motor_E" x="-.1475" y="-.135" z=".044" r="0.0" p="0.0" yaw="0.0"/>
+
+  <!-- F: Stern -->
+  <xacro:thrusters thrusterName="motor_F" x="0" y="-.019" z=".15" r="${pi/2}" p="0.0" yaw="0"/>
 
 
   <xacro:cameras cameraName="camera1" x="0.0" y="-0.32" z="0.0" r="0.0" p="0.0" yaw="0.0"/>

--- a/src/nautilus_worlds/scripts/sample_data.py
+++ b/src/nautilus_worlds/scripts/sample_data.py
@@ -7,7 +7,8 @@ from std_msgs.msg import Int16MultiArray
 dims = [MultiArrayDimension('data', 6, 16)]
 layout = MultiArrayLayout(dim=dims, data_offset=0)
 
-data = [1500 for _ in range(6)]
+# data = [1500 for _ in range(6)]
+data = [1505, 1505, 1500, 1500, 1500, 1501]
 msg = Int16MultiArray(layout=layout, data=data)
 print(msg)
 


### PR DESCRIPTION
This PR has the 3 reviewers @gunarp suggested I tag going forward. This particular PR is mostly to get people into the loop of things 👍

- Updated motor configurations to have a more intuitive A, B, C, D, E, F mapping between the motors. 
- The ROV can be driven now by feeding in sample PWM data via the `sample_data.py` script
- Instructions on how to run `sample_data.py` have been added to the README
- The Autopilot team can probably start looking at ways to interface with the sim. Updated instructions for how to run the sim with ROV 22 is on the README

Please feel free to message/ping me in the sim channel with questions!